### PR TITLE
feat: compact desktop layout and ensure full tree visibility

### DIFF
--- a/fractal-ui.css
+++ b/fractal-ui.css
@@ -58,11 +58,11 @@ body::before {
 .app {
   width: min(1240px, 100%);
   margin: 0 auto;
-  padding: clamp(16px, 2vw, 28px);
+  padding: clamp(12px, 1.4vw, 20px);
 }
 
 .hero {
-  padding: clamp(18px, 2.5vw, 32px);
+  padding: clamp(14px, 2vw, 24px);
   border-radius: 22px;
   border: 1px solid var(--border);
   background:
@@ -84,10 +84,10 @@ body::before {
 }
 
 .hero h1 {
-  margin: 6px 0 12px;
+  margin: 4px 0 10px;
   line-height: 1.04;
   letter-spacing: -0.03em;
-  font-size: clamp(2.1rem, 4.3vw, 3.7rem);
+  font-size: clamp(1.9rem, 3.8vw, 3.1rem);
 }
 
 .hero h1 span {
@@ -98,11 +98,11 @@ body::before {
   margin: 0;
   color: var(--muted);
   max-width: 64ch;
-  font-size: clamp(0.96rem, 1.35vw, 1.1rem);
+  font-size: clamp(0.9rem, 1.1vw, 1rem);
 }
 
 .hero-badges {
-  margin-top: 14px;
+  margin-top: 10px;
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
@@ -112,8 +112,8 @@ body::before {
   display: inline-flex;
   align-items: center;
   border-radius: 999px;
-  padding: 7px 11px;
-  font-size: 0.76rem;
+  padding: 5px 10px;
+  font-size: 0.72rem;
   letter-spacing: 0.01em;
   border: 1px solid rgba(255, 255, 255, 0.24);
   background: rgba(255, 255, 255, 0.05);
@@ -125,18 +125,18 @@ body::before {
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.14);
   background: rgba(0, 0, 0, 0.22);
-  padding: 14px;
+  padding: 11px;
 }
 
 .hero-hints h2 {
-  margin: 0 0 10px;
-  font-size: 0.95rem;
+  margin: 0 0 8px;
+  font-size: 0.9rem;
   color: var(--accent-2);
 }
 
 .hero-hints p {
-  margin: 8px 0;
-  font-size: 0.86rem;
+  margin: 6px 0;
+  font-size: 0.8rem;
   color: var(--muted);
   display: flex;
   align-items: center;
@@ -155,10 +155,10 @@ kbd {
 }
 
 .workspace {
-  margin-top: 18px;
+  margin-top: 12px;
   display: grid;
   grid-template-columns: minmax(290px, 340px) 1fr;
-  gap: 16px;
+  gap: 12px;
 }
 
 .panel,
@@ -171,7 +171,7 @@ kbd {
 }
 
 .panel {
-  padding: 16px;
+  padding: 12px;
 }
 
 .panel-heading h2 {
@@ -186,15 +186,15 @@ kbd {
 }
 
 .actions {
-  margin-top: 14px;
+  margin-top: 10px;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
+  gap: 7px;
 }
 
 .preset-block {
-  margin-top: 12px;
-  padding: 12px;
+  margin-top: 10px;
+  padding: 10px;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.11);
   background: rgba(0, 0, 0, 0.18);
@@ -240,11 +240,11 @@ kbd {
   appearance: none;
   border-radius: 12px;
   border: 1px solid transparent;
-  padding: 11px 12px;
+  padding: 9px 10px;
   color: var(--text);
   cursor: pointer;
   font-family: "IBM Plex Mono", "Lucida Console", monospace;
-  font-size: 0.81rem;
+  font-size: 0.76rem;
   background: rgba(255, 255, 255, 0.08);
   transition: transform 0.18s ease, background-color 0.18s ease, border-color 0.18s ease;
 }
@@ -300,16 +300,16 @@ select:not(#palette-input),
 }
 
 .controls {
-  margin-top: 14px;
+  margin-top: 10px;
   display: grid;
-  gap: 10px;
+  gap: 8px;
 }
 
 .control-group {
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.09);
   background: rgba(0, 0, 0, 0.2);
-  padding: 9px 10px 10px;
+  padding: 7px 9px 8px;
 }
 
 .control-group label {
@@ -317,7 +317,7 @@ select:not(#palette-input),
   justify-content: space-between;
   align-items: baseline;
   color: var(--muted);
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   gap: 8px;
 }
 
@@ -329,7 +329,7 @@ output {
 
 input[type="range"] {
   width: 100%;
-  margin: 8px 0 0;
+  margin: 6px 0 0;
   appearance: none;
   background: transparent;
 }
@@ -379,8 +379,8 @@ select {
 }
 
 .stats {
-  margin-top: 15px;
-  padding: 12px;
+  margin-top: 10px;
+  padding: 10px;
   border-radius: 14px;
   border: 1px solid rgba(255, 255, 255, 0.11);
   background: rgba(0, 0, 0, 0.22);
@@ -404,8 +404,8 @@ select {
   align-items: center;
   justify-content: space-between;
   color: var(--muted);
-  font-size: 0.84rem;
-  padding: 6px 2px;
+  font-size: 0.78rem;
+  padding: 4px 2px;
 }
 
 .stats strong {
@@ -415,7 +415,7 @@ select {
 
 .canvas-shell {
   overflow: hidden;
-  min-height: 620px;
+  min-height: 540px;
 }
 
 .canvas-header {
@@ -423,20 +423,20 @@ select {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 13px 14px;
+  padding: 10px 12px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
   background: var(--panel-strong);
 }
 
 .canvas-header h2 {
   margin: 0;
-  font-size: 1.04rem;
+  font-size: 1rem;
 }
 
 .canvas-header p {
   margin: 2px 0 0;
   color: var(--muted);
-  font-size: 0.8rem;
+  font-size: 0.76rem;
 }
 
 .canvas-tools {
@@ -454,21 +454,21 @@ select {
   border-radius: 10px;
   border: 1px solid rgba(255, 255, 255, 0.2);
   background: rgba(0, 0, 0, 0.2);
-  padding: 6px 8px;
+  padding: 5px 8px;
   font-size: 0.74rem;
   color: var(--muted);
   font-family: "IBM Plex Mono", "Lucida Console", monospace;
 }
 
 #seed-input {
-  width: 96px;
+  width: 84px;
   border: 0;
   outline: 0;
   padding: 0;
   color: var(--text);
   background: transparent;
   font-family: inherit;
-  font-size: 0.8rem;
+  font-size: 0.76rem;
 }
 
 .text-btn {
@@ -488,14 +488,14 @@ select {
 }
 
 .text-btn.compact {
-  padding: 8px 10px;
-  font-size: 0.76rem;
+  padding: 7px 9px;
+  font-size: 0.72rem;
   font-family: "IBM Plex Mono", "Lucida Console", monospace;
 }
 
 #canvas-host {
-  min-height: 560px;
-  padding: 12px;
+  min-height: 460px;
+  padding: 10px;
   display: grid;
   place-items: center;
   background:
@@ -505,19 +505,63 @@ select {
 }
 
 #canvas-host canvas {
-  width: 100% !important;
-  max-width: 760px;
-  height: auto !important;
-  border-radius: 16px;
+  max-width: 100%;
+  max-height: 100%;
+  display: block;
+  border-radius: 14px;
   border: 1px solid rgba(198, 229, 255, 0.2);
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
   animation: canvas-pop 380ms ease;
 }
 
 .footer {
-  margin-top: 12px;
+  margin-top: 8px;
   color: var(--muted);
-  font-size: 0.82rem;
+  font-size: 0.74rem;
+}
+
+@media (min-width: 1081px) {
+  .app {
+    height: 100vh;
+    padding: 12px 16px;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    gap: 10px;
+  }
+
+  .hero {
+    gap: 12px;
+    align-items: start;
+  }
+
+  .workspace {
+    margin-top: 0;
+    min-height: 0;
+    grid-template-columns: minmax(270px, 320px) 1fr;
+  }
+
+  .panel,
+  .canvas-shell {
+    min-height: 0;
+  }
+
+  .panel {
+    overflow: auto;
+  }
+
+  .canvas-shell {
+    display: flex;
+    flex-direction: column;
+  }
+
+  #canvas-host {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .footer {
+    margin-top: 0;
+  }
 }
 
 .footer a {

--- a/sketch.js
+++ b/sketch.js
@@ -15,6 +15,7 @@ const state = {
 };
 
 let treeCanvas;
+let hostResizeObserver;
 
 const paletteStops = {
   forest: ["#4f3221", "#2f7f54", "#abf26d"],
@@ -75,9 +76,15 @@ function setup() {
   cacheUi();
   bindUiEvents();
   bindKeyboardShortcuts();
+  observeHostResize();
   resizeToHost();
   randomizeConfig();
   renderTree();
+
+  window.requestAnimationFrame(() => {
+    resizeToHost();
+    renderTree();
+  });
 }
 
 function windowResized() {
@@ -91,7 +98,9 @@ function draw() {
   state.maxDepth = 0;
 
   randomSeed(state.seed);
-  translate(width / 2, height);
+  const fitScale = computeTreeFitScale();
+  translate(width / 2, height - 10);
+  scale(fitScale);
   branch(state.initialBranchSize, 0);
 
   updateStats();
@@ -439,9 +448,73 @@ function flashCopySeedFeedback(label) {
 function resizeToHost() {
   const host = document.getElementById("canvas-host");
   const hostWidth = host ? host.clientWidth : window.innerWidth;
-  const side = clamp(Math.floor(hostWidth - 28), 280, 760);
+  const hostHeight = host ? host.clientHeight : 0;
+  const maxByWidth = Math.floor(hostWidth - 24);
+  const fallbackByHeight = Math.floor(
+    window.innerHeight * (window.innerWidth > 1080 ? 0.54 : 0.72),
+  );
+  const maxByHeight = hostHeight > 40 ? Math.floor(hostHeight - 24) : fallbackByHeight;
+  const side = clamp(Math.min(maxByWidth, maxByHeight), 240, 760);
+
+  if (Math.abs(width - side) < 1 && Math.abs(height - side) < 1) {
+    return;
+  }
+
   resizeCanvas(side, side);
+  if (treeCanvas) {
+    treeCanvas.style("width", `${side}px`);
+    treeCanvas.style("height", `${side}px`);
+  }
   state.initialBranchSize = clamp(state.initialBranchSize, side * 0.2, side * 0.45);
+}
+
+function observeHostResize() {
+  const host = document.getElementById("canvas-host");
+
+  if (!host || typeof ResizeObserver === "undefined") {
+    return;
+  }
+
+  if (hostResizeObserver) {
+    hostResizeObserver.disconnect();
+  }
+
+  hostResizeObserver = new ResizeObserver(() => {
+    resizeToHost();
+    renderTree();
+  });
+
+  hostResizeObserver.observe(host);
+}
+
+function computeTreeFitScale() {
+  const pathLength = estimatePathLength(state.initialBranchSize, state.stopLen, state.size);
+  const angleFactor = clamp(Math.sin(Math.abs(state.angle)) * 0.72 + 0.22, 0.25, 0.95);
+  const estimatedHalfWidth = Math.max(
+    state.initialBranchSize * 0.4,
+    pathLength * angleFactor * 1.08,
+  );
+  const fitByHeight = (height * 0.86) / pathLength;
+  const fitByWidth = (width * 0.42) / estimatedHalfWidth;
+  return clamp(Math.min(1, fitByHeight, fitByWidth), 0.36, 1);
+}
+
+function estimatePathLength(initialLen, stopLen, sizeFactor) {
+  if (sizeFactor <= 0 || sizeFactor >= 1) {
+    return initialLen;
+  }
+
+  let total = 0;
+  let segment = initialLen;
+  let guard = 0;
+
+  while (segment > stopLen && guard < 80) {
+    total += segment;
+    segment *= sizeFactor;
+    guard += 1;
+  }
+
+  return total + segment;
 }
 
 function randomFloat(min, max) {


### PR DESCRIPTION
## Summary
- compacted desktop spacing so the full app fits a standard full-screen viewport
- kept global scrolling behavior available (no forced body scroll lock)
- improved canvas sizing to use host width and height constraints
- added host resize observation and redraw on container resize
- added tree fit scaling so branches remain fully visible in preview

## Validation
- checked syntax with `node --check sketch.js`
- verified at 1366x768 that the app fits without needing page scroll in normal desktop view
- tested multiple random seeds to confirm the tree stays inside preview bounds