### PR TITLE
Refine preview fact placement and simplify header copy

### DIFF
--- a/fractal-ui.css
+++ b/fractal-ui.css
@@ -528,50 +528,18 @@ input[type="range"]::-moz-range-thumb {
   font-family: "IBM Plex Mono", "Consolas", monospace;
 }
 
-.facts-card {
-  margin-top: 8px;
-  border-radius: 10px;
-  border: 1px solid rgba(50, 90, 150, 0.2);
-  background: rgba(245, 250, 255, 0.88);
-  padding: 7px;
-  display: grid;
-  gap: 6px;
-}
-
-.facts-title {
-  margin: 0;
-  color: #1f4b8f;
-  font-size: 0.66rem;
+.preview-fact-label {
+  color: #214b8f;
   font-weight: 800;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
+  margin-left: 0;
+  margin-right: 4px;
 }
 
-.fact-text {
-  margin: 0;
+.preview-fact-row {
+  margin: 4px 0 0;
   color: #4f6488;
-  font-size: 0.67rem;
-  line-height: 1.35;
-}
-
-.fact-live {
-  margin: 0;
-  border-radius: 8px;
-  border: 1px solid rgba(33, 84, 210, 0.14);
-  background: rgba(255, 255, 255, 0.72);
-  padding: 5px 6px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  color: #5a7093;
-  font-size: 0.64rem;
-}
-
-#fact-metric-value {
-  color: #1b3f7b;
-  font-family: "IBM Plex Mono", "Consolas", monospace;
   font-size: 0.66rem;
+  line-height: 1.25;
 }
 
 .canvas-shell {

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       rel="icon"
       href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ctext y='0.9em' font-size='52'%3E%F0%9F%8C%B3%3C/text%3E%3C/svg%3E"
     />
-    <link rel="stylesheet" href="./fractal-ui.css?v=20260227" />
+    <link rel="stylesheet" href="./fractal-ui.css?v=20260228" />
   </head>
   <body>
     <main class="app">
@@ -188,22 +188,17 @@
               <p><span>Branches</span><strong id="branches-value">-</strong></p>
               <p><span>Depth</span><strong id="depth-value">-</strong></p>
             </div>
-            <div class="facts-card" aria-live="polite">
-              <p class="facts-title">Fractal fact</p>
-              <p id="fact-text" class="fact-text">-</p>
-              <p class="fact-live">
-                <span id="fact-metric-label">Live insight</span>
-                <strong id="fact-metric-value">-</strong>
-              </p>
-            </div>
           </div>
         </aside>
 
         <section class="canvas-shell" aria-label="Tree preview">
           <div class="canvas-header">
-            <div>
+            <div class="canvas-intro">
               <h2>Preview</h2>
-              <p>Each seed generates a distinct composition.</p>
+              <p class="preview-fact-row" aria-live="polite">
+                <span class="preview-fact-label">Fractal Fact:</span>
+                <span id="fact-text">-</span>
+              </p>
             </div>
             <div class="canvas-tools">
               <button

--- a/sketch.js
+++ b/sketch.js
@@ -74,8 +74,6 @@ const ui = {
   branchesValue: null,
   depthValue: null,
   factText: null,
-  factMetricLabel: null,
-  factMetricValue: null,
   seedInput: null,
   applySeedBtn: null,
   applySeedFeedbackTimer: null,
@@ -263,8 +261,6 @@ function cacheUi() {
   ui.branchesValue = document.getElementById("branches-value");
   ui.depthValue = document.getElementById("depth-value");
   ui.factText = document.getElementById("fact-text");
-  ui.factMetricLabel = document.getElementById("fact-metric-label");
-  ui.factMetricValue = document.getElementById("fact-metric-value");
   ui.seedInput = document.getElementById("seed-input");
   ui.applySeedBtn = document.getElementById("apply-seed-btn");
   ui.copySeedBtn = document.getElementById("copy-seed-btn");
@@ -737,39 +733,12 @@ function updateStats() {
 }
 
 function updateFractalFacts() {
-  if (!ui.factText || !ui.factMetricLabel || !ui.factMetricValue) {
+  if (!ui.factText) {
     return;
   }
 
   const factIndex = Math.abs(state.seed) % fractalFactCatalog.length;
   ui.factText.textContent = fractalFactCatalog[factIndex];
-
-  const liveInsights = [
-    {
-      label: "Estimated twig tips",
-      value: `~${Math.round(Math.pow(2, Math.max(0, state.maxDepth))).toLocaleString()}`,
-    },
-    {
-      label: "Canopy angle span",
-      value: `${Math.round((state.angle * 360) / Math.PI)}deg`,
-    },
-    {
-      label: "Length left after 5 splits",
-      value: `${Math.round(Math.pow(state.size, 5) * 100)}%`,
-    },
-    {
-      label: "Current recursion depth",
-      value: `${state.maxDepth} levels`,
-    },
-    {
-      label: "Branches per depth level",
-      value: `${(state.branchCount / Math.max(1, state.maxDepth + 1)).toFixed(1)}`,
-    },
-  ];
-
-  const liveInsight = liveInsights[factIndex % liveInsights.length];
-  ui.factMetricLabel.textContent = liveInsight.label;
-  ui.factMetricValue.textContent = liveInsight.value;
 }
 
 function setActivePreset(activePreset) {


### PR DESCRIPTION
## Summary
- moves the `Fractal Fact` line directly below the `Preview` title
- removes `Each seed generates a distinct composition.` from the preview header
- removes the extra live-metric fragment so only the fact text remains
- keeps fact updates tied to seed changes

## Why
- keeps the preview header cleaner and easier to scan
- aligns with the requested layout: title + fact on the left, controls on the right

## Validation
- syntax check: `node --check sketch.js`
- manual visual check in browser (`http://localhost:4173`) confirmed:
  - no duplicate fact labels
  - fact appears below `Preview`
  - seed controls stay aligned