### PR TITLE
Polish dark mode toggle and unify icon-only canvas actions

### DIFF
--- a/fractal-ui.css
+++ b/fractal-ui.css
@@ -133,13 +133,13 @@ html[data-theme="dark"] body::before {
 
 .hero-title-row {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 10px;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 9px;
 }
 
 .hero-title-row h1 {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   min-width: 0;
 }
 
@@ -158,35 +158,42 @@ html[data-theme="dark"] body::before {
 
 .theme-toggle-btn {
   appearance: none;
-  border: 1px solid rgba(33, 84, 210, 0.26);
+  border: 0;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.84);
+  background: transparent;
   color: #275093;
-  min-height: 32px;
-  padding: 5px 10px;
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
+  width: 30px;
+  min-width: 30px;
+  height: 30px;
+  padding: 0;
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 30px;
   cursor: pointer;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.01em;
   transition:
-    border-color 180ms ease,
-    background-color 180ms ease,
-    color 180ms ease,
-    transform 180ms ease;
+    color 220ms ease,
+    transform 220ms ease,
+    opacity 220ms ease;
 }
 
 .theme-toggle-btn:hover {
-  border-color: rgba(33, 84, 210, 0.42);
-  background: rgba(255, 255, 255, 0.98);
+  color: #1b4aa0;
   transform: translateY(-1px);
+  opacity: 0.92;
+}
+
+.theme-toggle-btn:active {
+  transform: translateY(0) scale(0.95);
+}
+
+.theme-toggle-btn:focus-visible {
+  outline: 2px solid rgba(33, 84, 210, 0.34);
+  outline-offset: 3px;
 }
 
 .theme-toggle-icon {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
   display: inline-grid;
   place-items: center;
   position: relative;
@@ -194,35 +201,31 @@ html[data-theme="dark"] body::before {
 }
 
 .theme-toggle-icon .icon-glyph {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
   position: absolute;
   inset: 0;
-  transition: opacity 180ms ease, transform 220ms ease;
+  transition: opacity 260ms ease, transform 340ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 .theme-toggle-icon .icon-sun {
-  opacity: 0;
-  transform: scale(0.74) rotate(-20deg);
+  opacity: 1;
+  transform: scale(1) rotate(0deg);
 }
 
 .theme-toggle-icon .icon-moon {
-  opacity: 1;
-  transform: scale(1) rotate(0deg);
+  opacity: 0;
+  transform: scale(0.48) rotate(-70deg);
 }
 
 .theme-toggle-btn.is-dark .theme-toggle-icon .icon-sun {
-  opacity: 1;
-  transform: scale(1) rotate(0deg);
+  opacity: 0;
+  transform: scale(0.48) rotate(70deg);
 }
 
 .theme-toggle-btn.is-dark .theme-toggle-icon .icon-moon {
-  opacity: 0;
-  transform: scale(0.74) rotate(18deg);
-}
-
-#theme-toggle-label {
-  font-family: "IBM Plex Mono", "Consolas", monospace;
+  opacity: 1;
+  transform: scale(1) rotate(0deg);
 }
 
 .hero-title-icon {
@@ -371,7 +374,7 @@ select:focus-visible {
   outline-offset: 2px;
 }
 
-button:not(.btn):not(.text-btn),
+button:not(.btn):not(.text-btn):not(.theme-toggle-btn),
 .p5Button {
   appearance: none;
   border-radius: 10px;
@@ -880,6 +883,13 @@ button.fact-icon-btn:not(.btn):not(.text-btn).is-feedback {
   color: #1b498f;
 }
 
+#redraw-btn.bare-icon {
+  width: 28px;
+  min-width: 28px;
+  border-color: transparent;
+  background: transparent;
+}
+
 #redraw-btn .icon-rotate {
   width: 17.5px;
   height: 17.5px;
@@ -942,6 +952,8 @@ button.fact-icon-btn:not(.btn):not(.text-btn).is-feedback {
 
 .bare-icon.icon-btn {
   border: 0;
+  border-color: transparent;
+  background: transparent;
 }
 
 @keyframes icon-toast {
@@ -1229,15 +1241,11 @@ html[data-theme="dark"] .hero-copy {
 }
 
 html[data-theme="dark"] .theme-toggle-btn {
-  border-color: rgba(130, 162, 214, 0.36);
-  background: rgba(18, 31, 52, 0.86);
-  color: #b7c9eb;
+  color: #d3e1fb;
 }
 
 html[data-theme="dark"] .theme-toggle-btn:hover {
-  border-color: rgba(157, 188, 236, 0.5);
-  background: rgba(26, 41, 66, 0.95);
-  color: #d2def5;
+  color: #f0f6ff;
 }
 
 html[data-theme="dark"] .hero-hints {
@@ -1310,7 +1318,7 @@ html[data-theme="dark"] select:focus-visible {
   outline-color: rgba(124, 157, 214, 0.68);
 }
 
-html[data-theme="dark"] button:not(.btn):not(.text-btn),
+html[data-theme="dark"] button:not(.btn):not(.text-btn):not(.theme-toggle-btn),
 html[data-theme="dark"] .p5Button,
 html[data-theme="dark"] select:not(#palette-input),
 html[data-theme="dark"] .p5Select {
@@ -1663,19 +1671,11 @@ html[data-theme="dark"] .privacy-updated {
     border-radius: 18px;
   }
 
-  .hero-title-row {
-    align-items: center;
-  }
-
   .theme-toggle-btn {
-    min-width: 32px;
-    width: 32px;
-    padding: 6px;
-    justify-content: center;
-  }
-
-  #theme-toggle-label {
-    display: none;
+    width: 30px;
+    min-width: 30px;
+    height: 30px;
+    flex-basis: 30px;
   }
 
   .hero-hints {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -8,14 +8,7 @@
       rel="icon"
       href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ctext y='0.9em' font-size='52'%3E%F0%9F%8C%B3%3C/text%3E%3C/svg%3E"
     />
-    <script>
-      (() => {
-        const prefersDark =
-          window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-        document.documentElement.dataset.theme = prefersDark ? "dark" : "light";
-      })();
-    </script>
-    <link rel="stylesheet" href="./fractal-ui.css?v=20260228" />
+    <link rel="stylesheet" href="./fractal-ui.css?v=20260301" />
   </head>
   <body>
     <main class="app">
@@ -47,7 +40,6 @@
                   <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9"></path>
                 </svg>
               </span>
-              <span id="theme-toggle-label">Dark mode</span>
             </button>
           </div>
           <p class="hero-copy">

--- a/sketch.js
+++ b/sketch.js
@@ -90,7 +90,6 @@ const ui = {
   redrawSpinTimer: null,
   copySeedDefaultLabel: "Copy seed",
   themeToggleBtn: null,
-  themeToggleLabel: null,
   openPrivacyBtn: null,
   closePrivacyBtn: null,
   privacyModal: null,
@@ -276,7 +275,6 @@ function cacheUi() {
   ui.applySeedBtn = document.getElementById("apply-seed-btn");
   ui.copySeedBtn = document.getElementById("copy-seed-btn");
   ui.themeToggleBtn = document.getElementById("theme-toggle-btn");
-  ui.themeToggleLabel = document.getElementById("theme-toggle-label");
   ui.openPrivacyBtn = document.getElementById("open-privacy-btn");
   ui.closePrivacyBtn = document.getElementById("close-privacy-btn");
   ui.privacyModal = document.getElementById("privacy-modal");
@@ -426,7 +424,6 @@ function toggleTheme() {
 function applyTheme(theme) {
   const normalizedTheme = theme === themes.dark ? themes.dark : themes.light;
   const isDark = normalizedTheme === themes.dark;
-  const nextToggleLabel = isDark ? "Light mode" : "Dark mode";
   const nextAriaLabel = isDark ? "Switch to light mode" : "Switch to dark mode";
 
   document.documentElement.dataset.theme = normalizedTheme;
@@ -439,10 +436,6 @@ function applyTheme(theme) {
   ui.themeToggleBtn.setAttribute("aria-pressed", `${isDark}`);
   ui.themeToggleBtn.setAttribute("aria-label", nextAriaLabel);
   ui.themeToggleBtn.setAttribute("title", nextAriaLabel);
-
-  if (ui.themeToggleLabel) {
-    ui.themeToggleLabel.textContent = nextToggleLabel;
-  }
 }
 
 function bindPaletteSelectEvents() {


### PR DESCRIPTION
## Summary
- set light theme as default and keep dark mode optional via toggle
- move the theme toggle next to the title and switch it to icon-only UI
- animate sun/moon transition with CSS for smoother theme state change
- remove unintended button chrome from bare icon actions
- align `copy` and `regenerate` so both are clean icon-only controls

## Notes
- regenerate keeps a temporary green state only while spinning/refreshing
- accessibility labels/titles remain in place for icon-only controls

## Validation
- `node --check sketch.js`