### PR TITLE
Expand fractal facts and polish visual hierarchy across themes

### DIFF
--- a/fractal-ui.css
+++ b/fractal-ui.css
@@ -209,7 +209,10 @@ html[data-theme="dark"] body::before {
   height: 18px;
   position: absolute;
   inset: 0;
-  transition: opacity 260ms ease, transform 340ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transform-origin: 50% 50%;
+  transition:
+    opacity 420ms cubic-bezier(0.22, 0.7, 0.2, 1),
+    transform 680ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 .theme-toggle-icon .icon-sun {
@@ -219,12 +222,12 @@ html[data-theme="dark"] body::before {
 
 .theme-toggle-icon .icon-moon {
   opacity: 0;
-  transform: scale(0.48) rotate(-70deg);
+  transform: scale(0.4) rotate(-96deg);
 }
 
 .theme-toggle-btn.is-dark .theme-toggle-icon .icon-sun {
   opacity: 0;
-  transform: scale(0.48) rotate(70deg);
+  transform: scale(0.4) rotate(96deg);
 }
 
 .theme-toggle-btn.is-dark .theme-toggle-icon .icon-moon {
@@ -287,6 +290,19 @@ kbd {
   font-size: 0.76rem;
   font-weight: 600;
   padding: 2px 8px;
+  transition:
+    color 180ms ease,
+    border-color 180ms ease,
+    background-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+kbd.is-shortcut-active {
+  border-color: rgba(36, 135, 91, 0.65);
+  background: rgba(211, 245, 229, 0.96);
+  color: #17684a;
+  animation: shortcut-press 560ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 .workspace {
@@ -1405,6 +1421,12 @@ html[data-theme="dark"] kbd {
   color: #c6d6ee;
 }
 
+html[data-theme="dark"] kbd.is-shortcut-active {
+  border-color: rgba(109, 208, 164, 0.74);
+  background: rgba(20, 74, 55, 0.92);
+  color: #d9ffef;
+}
+
 html[data-theme="dark"] .panel,
 html[data-theme="dark"] .canvas-shell {
   border-color: var(--line);
@@ -1538,6 +1560,23 @@ html[data-theme="dark"] .preset-btn.is-active {
     box-shadow:
       0 0 0 0 rgba(141, 175, 233, 0.3),
       0 0 0 0 rgba(141, 175, 233, 0.12);
+  }
+}
+
+@keyframes shortcut-press {
+  0% {
+    transform: translateY(0) scale(1);
+    box-shadow: 0 0 0 0 rgba(48, 163, 113, 0.4);
+  }
+
+  40% {
+    transform: translateY(-1px) scale(1.04);
+    box-shadow: 0 0 0 8px rgba(48, 163, 113, 0.22);
+  }
+
+  100% {
+    transform: translateY(0) scale(1);
+    box-shadow: 0 0 0 0 rgba(48, 163, 113, 0);
   }
 }
 
@@ -1822,7 +1861,8 @@ html[data-theme="dark"] .privacy-updated {
 
   #redraw-btn.is-spinning .icon-rotate,
   #apply-seed-btn.is-success .apply-check-icon,
-  .bare-icon.icon-btn.is-feedback::after {
+  .bare-icon.icon-btn.is-feedback::after,
+  kbd.is-shortcut-active {
     animation: none;
   }
 }

--- a/index.html
+++ b/index.html
@@ -55,9 +55,9 @@
 
         <aside class="hero-hints" aria-label="Keyboard shortcuts">
           <h2>Shortcuts</h2>
-          <p><kbd>R</kbd> New random tree</p>
-          <p><kbd>M</kbd> Soft mutation</p>
-          <p><kbd>S</kbd> Save PNG</p>
+          <p><kbd data-shortcut-key="r">R</kbd> New random tree</p>
+          <p><kbd data-shortcut-key="m">M</kbd> Soft mutation</p>
+          <p><kbd data-shortcut-key="s">S</kbd> Save PNG</p>
         </aside>
       </section>
 

--- a/sketch.js
+++ b/sketch.js
@@ -213,6 +213,8 @@ const ui = {
   presetCurrentLabel: null,
   presetButtons: [],
   presetLabelTransitionTimer: null,
+  shortcutKeyHints: new Map(),
+  shortcutFeedbackTimers: new Map(),
 };
 
 function setup() {
@@ -397,6 +399,11 @@ function cacheUi() {
   ui.privacyModal = document.getElementById("privacy-modal");
   ui.presetCurrentLabel = document.getElementById("preset-current-label");
   ui.presetButtons = Array.from(document.querySelectorAll("[data-preset]"));
+  ui.shortcutKeyHints = new Map(
+    Array.from(document.querySelectorAll("[data-shortcut-key]")).map((element) => {
+      return [element.dataset.shortcutKey, element];
+    }),
+  );
 
   if (ui.applySeedBtn) {
     ui.applySeedDefaultLabel = ui.applySeedBtn.getAttribute("aria-label") || "Apply seed";
@@ -855,6 +862,7 @@ function bindKeyboardShortcuts() {
 
     if (key === "r") {
       event.preventDefault();
+      flashShortcutHint("r");
       randomizeConfig();
       renderTree();
       return;
@@ -862,15 +870,43 @@ function bindKeyboardShortcuts() {
 
     if (key === "m") {
       event.preventDefault();
+      flashShortcutHint("m");
       mutateConfig();
       return;
     }
 
     if (key === "s") {
       event.preventDefault();
+      flashShortcutHint("s");
       saveCanvas(treeCanvas, `fractal-tree-${state.seed}`, "png");
     }
   });
+}
+
+function flashShortcutHint(key) {
+  const target = ui.shortcutKeyHints.get(key);
+
+  if (!target) {
+    return;
+  }
+
+  const previousTimer = ui.shortcutFeedbackTimers.get(key);
+
+  if (previousTimer) {
+    window.clearTimeout(previousTimer);
+    ui.shortcutFeedbackTimers.delete(key);
+  }
+
+  target.classList.remove("is-shortcut-active");
+  void target.offsetWidth;
+  target.classList.add("is-shortcut-active");
+
+  const timer = window.setTimeout(() => {
+    target.classList.remove("is-shortcut-active");
+    ui.shortcutFeedbackTimers.delete(key);
+  }, 620);
+
+  ui.shortcutFeedbackTimers.set(key, timer);
 }
 
 function syncInputsFromState() {


### PR DESCRIPTION
## Summary
- expand `fractalFactCatalog` to 120 verified facts in English
- reduce Apply button visual weight to better match seed controls
- refine dark mode with tonal hierarchy (less neon, clearer elevation, better contrast)
- add multi-tone text emphasis in the hero and section copy
- improve readability of compact UI text (small type scale and tabular numerals)
- polish interaction states (hover/active/focus) for buttons and panels

## Visual polish details
- stronger semantic emphasis for key phrases in title/subtitles
- cleaner fact row readability and subtle emphasis on fact content
- more consistent icon/button behavior in both light and dark themes

## Validation
- `node --check sketch.js`